### PR TITLE
fix: typing-extensions ver for Semantic Versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf8") as f:
 
 setuptools.setup(
     name="simple_di",
-    version="0.1.2",
+    version="0.1.3",
     author="bojiang",
     author_email="bojiang_@outlook.com",
     description="simple dependency injection library",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
     install_requires=[
         'dataclasses; python_version < "3.7.0"',
         'types-dataclasses; python_version < "3.7.0"',
-        'typing-extensions',
+        'typing-extensions < 4',
     ],
     extras_require={"test": ["pytest", "mypy"]},
 )


### PR DESCRIPTION
Due to the Semantic Versioning decision of typing_textensions 
https://github.com/python/typing/tree/master/typing_extensions#overview

Starting with version 4.0.0, typing_extensions uses Semantic Versioning. The major version is incremented for all backwards-incompatible changes, including dropping support for older Python versions. Therefore, it's safe to depend on typing_extensions like this: typing_extensions >=x.y, <(x+1), where x.y is the first version that includes all features you need.